### PR TITLE
feat: Implement Staff Profile management functionality

### DIFF
--- a/server/RecruitmentSystem/RecruitmentSystem.API/Controllers/AuthenticationController.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.API/Controllers/AuthenticationController.cs
@@ -123,7 +123,8 @@ namespace RecruitmentSystem.API.Controllers
                 var user = await _userManager.FindByEmailAsync(dto.Email);
                 if (user != null)
                 {
-                    await _emailService.SendWelcomeEmailAsync(user.Email!, user.FirstName!);
+                    var roles = string.Join(", ", dto.Roles);
+                    await _emailService.SendStaffRegistrationEmailAsync(user.Email!, user.FirstName!, roles);
                 }
 
                 return Ok(ApiResponse<AuthResponseDto>.SuccessResponse(result, "Staff registration successful"));

--- a/server/RecruitmentSystem/RecruitmentSystem.API/Controllers/StaffProfileController.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.API/Controllers/StaffProfileController.cs
@@ -1,0 +1,265 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using RecruitmentSystem.Core.Entities;
+using RecruitmentSystem.Services.Interfaces;
+using RecruitmentSystem.Shared.DTOs;
+using RecruitmentSystem.Shared.DTOs.Responses;
+
+namespace RecruitmentSystem.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    [Authorize(Roles = "SuperAdmin, Admin, HR, Recruiter")]
+    public class StaffProfileController : ControllerBase
+    {
+        private readonly IStaffProfileService _staffProfileService;
+        private readonly ILogger<StaffProfileController> _logger;
+        private readonly UserManager<User> _userManager;
+
+        public StaffProfileController(
+            IStaffProfileService staffProfileService,
+            ILogger<StaffProfileController> logger,
+            UserManager<User> userManager)
+        {
+            _staffProfileService = staffProfileService;
+            _logger = logger;
+            _userManager = userManager;
+        }
+
+        /// <summary>
+        /// Get staff profile by Id
+        /// </summary>
+        [HttpGet("{id}")]
+        public async Task<ActionResult<StaffProfileResponseDto>> GetById(Guid id)
+        {
+            try
+            {
+                var profile = await _staffProfileService.GetByIdAsync(id);
+                if (profile == null)
+                {
+                    return NotFound(ApiResponse<CandidateRegisterDto>.FailureResponse(new List<string> { $"Staff profile with ID {id} not found!" }, "Not Found"));
+                }
+
+                // Check ownership/permission
+                if (!CanAccessProfile(profile.UserId))
+                {
+                    return Forbid();
+                }
+
+                return Ok(ApiResponse<StaffProfileResponseDto>.SuccessResponse(profile, "Profile retrieved successfully"));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retriving staff profile with ID {Id}", id);
+                return StatusCode(500, ApiResponse<CandidateRegisterDto>.FailureResponse(new List<string> { "An error occurred while retrieving the staff profile." }, "Internal Server Error"));
+            }
+        }
+
+        /// <summary>
+        /// Get staff profile by UserId
+        /// </summary>
+        [HttpGet("user/{userId}")]
+        public async Task<ActionResult<StaffProfileResponseDto>> GetByUserId(Guid userId)
+        {
+            try
+            {
+                var profile = await _staffProfileService.GetByUserIdAsync(userId);
+                if (profile == null)
+                {
+                    return NotFound(ApiResponse<CandidateRegisterDto>.FailureResponse(new List<string> { $"Staff profile for User ID {userId} not found!" }, "Not Found"));
+                }
+
+                // Check ownership/permission
+                if (!CanAccessProfile(profile.UserId))
+                {
+                    return Forbid();
+                }
+
+                return Ok(ApiResponse<StaffProfileResponseDto>.SuccessResponse(profile, "Profile retrieved successfully"));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving staff profile for User ID {UserId}", userId);
+                return StatusCode(500, ApiResponse<CandidateRegisterDto>.FailureResponse(new List<string> { "An error occurred while retrieving the staff profile." }, "Internal Server Error"));
+            }
+        }
+
+        /// <summary>
+        /// Get Current user's staff profile
+        /// </summary>
+        [HttpGet("my-profile")]
+        public async Task<ActionResult<StaffProfileResponseDto>> GetMyProfile()
+        {
+            try
+            {
+                var userId = GetCurrentUserId();
+                var profile = await _staffProfileService.GetByUserIdAsync(userId);
+                if (profile == null)
+                {
+                    return NotFound(ApiResponse<CandidateRegisterDto>.FailureResponse(new List<string> { "Staff profile not found for the current user!" }, "Not Found"));
+                }
+
+                return Ok(ApiResponse<StaffProfileResponseDto>.SuccessResponse(profile, "Profile retrieved successfully"));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving current user's staff profile");
+                return StatusCode(500, ApiResponse<CandidateRegisterDto>.FailureResponse(new List<string> { "An error occurred while retrieving the staff profile." }, "Internal Server Error"));
+            }
+        }
+
+        /// <summary>
+        /// Create a new staff profile
+        /// </summary>
+        [HttpPost]
+        public async Task<ActionResult<StaffProfileResponseDto>> CreateProfile([FromBody] CreateStaffProfileDto dto)
+        {
+            Guid userId = Guid.Empty;
+            try
+            {
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ApiResponse<StaffProfileResponseDto>.FailureResponse(ModelState.Values.SelectMany(v => v.Errors).Select(e => e.ErrorMessage).ToList(), "Invalid Data"));
+                }
+
+                userId = GetCurrentUserId();
+                var profile = await _staffProfileService.CreateProfileAsync(dto, userId);
+
+                return CreatedAtAction(nameof(GetById), new { id = profile.Id }, ApiResponse<StaffProfileResponseDto>.SuccessResponse(profile, "Profile created successfully"));
+
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Business rule violation while creating staff profile for user {UserId}", userId);
+                return Conflict(ApiResponse<StaffProfileResponseDto>.FailureResponse(new List<string> { ex.Message }, "Conflict"));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating staff profile for user {UserId}", userId);
+                return StatusCode(500, ApiResponse<StaffProfileResponseDto>.FailureResponse(new List<string> { "An error occurred while creating the staff profile." }, "Internal Server Error"));
+            }
+        }
+
+        /// <summary>
+        /// Update an existing staff profile
+        /// </summary>
+        [HttpPatch("{id}")]
+        public async Task<ActionResult<StaffProfileResponseDto>> UpdateProfile(Guid id, [FromBody] UpdateStaffProfileDto dto)
+        {
+            try
+            {
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ApiResponse<StaffProfileResponseDto>.FailureResponse(ModelState.Values.SelectMany(v => v.Errors).Select(e => e.ErrorMessage).ToList(), "Invalid Data"));
+                }
+
+                var profile = await _staffProfileService.UpdateProfileAsync(id, dto);
+                if (profile == null)
+                {
+                    return NotFound(ApiResponse<StaffProfileResponseDto>.FailureResponse(new List<string> { $"Staff profile with ID {id} not found" }, "Not Found"));
+                }
+
+                // Check ownership/permission
+                if (!CanAccessProfile(profile.UserId))
+                {
+                    return Forbid();
+                }
+
+                return Ok(ApiResponse<StaffProfileResponseDto>.SuccessResponse(profile, "Profile updated successfully"));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating staff profile with ID {Id}", id);
+                return StatusCode(500, ApiResponse<StartupBase>.FailureResponse(new List<string> { "An error occurred while updating the staff profile" }, "Couldn't Update Profile"));
+            }
+        }
+
+        /// <summary>
+        /// Delete a staff profile
+        /// </summary>
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> DeleteProfile(Guid id)
+        {
+            try
+            {
+                var currentUserId = GetCurrentUserId();
+                var currentUser = await _userManager.FindByIdAsync(currentUserId.ToString());
+                if (currentUser == null)
+                {
+                    return Unauthorized(ApiResponse.FailureResponse(new List<string> { "Current user not found." }));
+                }
+
+                var profile = await _staffProfileService.GetByIdAsync(id);
+                if (profile == null)
+                {
+                    return NotFound(ApiResponse.FailureResponse(new List<string> { $"Staff profile with ID {id} not found." }));
+                }
+
+                var targetUser = await _userManager.FindByIdAsync(profile.UserId.ToString());
+                if (targetUser == null)
+                {
+                    return NotFound(ApiResponse.FailureResponse(new List<string> { "Associated user not found." }));
+                }
+
+                var targetRoles = await _userManager.GetRolesAsync(targetUser);
+
+                // SuperAdmin profiles can only be deleted by themselves
+                if (targetRoles.Contains("SuperAdmin") && currentUserId != profile.UserId)
+                {
+                    return Forbid("Cannot delete SuperAdmin profiles.");
+                }
+
+                // Allow deletion if deleting self or has admin privileges
+                var currentRoles = await _userManager.GetRolesAsync(currentUser);
+                bool isAuthorized = currentUserId == profile.UserId || currentRoles.Contains("SuperAdmin") || currentRoles.Contains("Admin") || currentRoles.Contains("HR");
+
+                if (!isAuthorized)
+                {
+                    return Forbid("You do not have permission to delete this profile.");
+                }
+
+                var deleted = await _staffProfileService.DeleteProfileAsync(id);
+                if (!deleted)
+                {
+                    return NotFound(ApiResponse.FailureResponse(new List<string> { $"Staff profile with ID {id} not found or could not be deleted." }));
+                }
+
+                return Ok(ApiResponse.SuccessResponse("Profile deleted successfully."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deleting staff profile with ID {Id}", id);
+                return StatusCode(500, ApiResponse.FailureResponse(new List<string> { "An error occurred while deleting the staff profile." }));
+            }
+        }
+
+        #region Private Methods
+
+        private Guid GetCurrentUserId()
+        {
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+            {
+                throw new UnauthorizedAccessException("User Id not found in token");
+            }
+            return userId;
+        }
+
+        private bool CanAccessProfile(Guid profileUserId)
+        {
+            var currentUserId = GetCurrentUserId();
+            var currentUserRole = User.FindFirst(ClaimTypes.Role)?.Value;
+
+            // SuperAdmins and Admins can access all profiles
+            if (currentUserRole == "SuperAdmin" || currentUserRole == "Admin" || currentUserRole == "HR")
+                return true;
+
+            // Recruiters can only access their own profile
+            return profileUserId == currentUserId;
+        }
+
+        #endregion
+    }
+}

--- a/server/RecruitmentSystem/RecruitmentSystem.Core/Entities/StaffProfile.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Core/Entities/StaffProfile.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RecruitmentSystem.Core.Entities
+{
+    public class StaffProfile : BaseEntity
+    {
+        // Foreign key to User
+        [Required]
+        public Guid UserId { get; set; }
+
+        [Required]
+        [StringLength(50)]
+        public required string EmployeeCode { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public required string Department { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public required string Location { get; set; }
+
+        [Required]
+        [StringLength(50)]
+        public required string Status { get; set; }
+
+        public DateTime? JoinedDate { get; set; }
+
+        // Navigation property
+        [ForeignKey("UserId")]
+        public virtual required User User { get; set; }
+    }
+}

--- a/server/RecruitmentSystem/RecruitmentSystem.Core/Interfaces/IStaffProfileRepository.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Core/Interfaces/IStaffProfileRepository.cs
@@ -1,0 +1,18 @@
+using RecruitmentSystem.Core.Entities;
+
+namespace RecruitmentSystem.Core.Interfaces
+{
+    public interface IStaffProfileRepository
+    {
+        Task<StaffProfile?> GetByIdAsync(Guid id);
+        Task<StaffProfile?> GetByUserIdAsync(Guid userId);
+        Task<StaffProfile?> GetByEmployeeCodeAsync(string employeeCode);
+        Task<StaffProfile> CreateAsync(StaffProfile profile);
+        Task<StaffProfile> UpdateAsync(StaffProfile profile);
+        Task<bool> DeleteAsync(Guid id);
+        Task<bool> ExistsAsync(Guid id);
+        Task<bool> ExistsByUserIdAsync(Guid userId);
+        Task<IEnumerable<StaffProfile>> GetByDepartmentAsync(string department);
+        Task<IEnumerable<StaffProfile>> GetActiveStaffAsync();
+    }
+}

--- a/server/RecruitmentSystem/RecruitmentSystem.Infrastructure/Migrations/20250925103134_UpdateStaffProfile.Designer.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Infrastructure/Migrations/20250925103134_UpdateStaffProfile.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using RecruitmentSystem.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using RecruitmentSystem.Infrastructure.Data;
 namespace RecruitmentSystem.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250925103134_UpdateStaffProfile")]
+    partial class UpdateStaffProfile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/RecruitmentSystem/RecruitmentSystem.Infrastructure/Migrations/20250925103134_UpdateStaffProfile.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Infrastructure/Migrations/20250925103134_UpdateStaffProfile.cs
@@ -1,0 +1,522 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RecruitmentSystem.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateStaffProfile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_StaffProfiles_Users_ReportingManagerId",
+                table: "StaffProfiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_StaffProfiles_ReportingManagerId",
+                table: "StaffProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Designation",
+                table: "StaffProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "ReportingManagerId",
+                table: "StaffProfiles");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Skills",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Category",
+                table: "Skills",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Roles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Location",
+                table: "CandidateWorkExperiences",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "JobDescription",
+                table: "CandidateWorkExperiences",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1000)",
+                oldMaxLength: 1000);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EmploymentType",
+                table: "CandidateWorkExperiences",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Source",
+                table: "CandidateProfiles",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ResumeFilePath",
+                table: "CandidateProfiles",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ResumeFileName",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PortfolioUrl",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LinkedInProfile",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "GitHubProfile",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Degree",
+                table: "CandidateProfiles",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CurrentLocation",
+                table: "CandidateProfiles",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "College",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "GPA",
+                table: "CandidateEducations",
+                type: "decimal(4,2)",
+                nullable: false,
+                defaultValue: 0m,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(4,2)",
+                oldNullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("1a73a5b5-bf8f-4398-9a31-0d136fd62ac1"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 25, 10, 31, 32, 888, DateTimeKind.Utc).AddTicks(7256));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("2c73a5b5-bf8f-4398-9a31-0d136fd62ac2"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 25, 10, 31, 32, 888, DateTimeKind.Utc).AddTicks(8904));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("3b73a5b5-bf8f-4398-9a31-0d136fd62ac3"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 25, 10, 31, 32, 888, DateTimeKind.Utc).AddTicks(8945));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("4d73a5b5-bf8f-4398-9a31-0d136fd62ac4"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 25, 10, 31, 32, 888, DateTimeKind.Utc).AddTicks(8947));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("5e73a5b5-bf8f-4398-9a31-0d136fd62ac5"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 25, 10, 31, 32, 888, DateTimeKind.Utc).AddTicks(8948));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("6f73a5b5-bf8f-4398-9a31-0d136fd62ac6"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 25, 10, 31, 32, 888, DateTimeKind.Utc).AddTicks(8949));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("7a73a5b5-bf8f-4398-9a31-0d136fd62ac7"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 25, 10, 31, 32, 888, DateTimeKind.Utc).AddTicks(8951));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("8b73a5b5-bf8f-4398-9a31-0d136fd62ac8"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 25, 10, 31, 32, 888, DateTimeKind.Utc).AddTicks(8952));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Designation",
+                table: "StaffProfiles",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ReportingManagerId",
+                table: "StaffProfiles",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Skills",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Category",
+                table: "Skills",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Roles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Location",
+                table: "CandidateWorkExperiences",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "JobDescription",
+                table: "CandidateWorkExperiences",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1000)",
+                oldMaxLength: 1000,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EmploymentType",
+                table: "CandidateWorkExperiences",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Source",
+                table: "CandidateProfiles",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ResumeFilePath",
+                table: "CandidateProfiles",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ResumeFileName",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "PortfolioUrl",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "LinkedInProfile",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "GitHubProfile",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Degree",
+                table: "CandidateProfiles",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CurrentLocation",
+                table: "CandidateProfiles",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "College",
+                table: "CandidateProfiles",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "GPA",
+                table: "CandidateEducations",
+                type: "decimal(4,2)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(4,2)");
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("1a73a5b5-bf8f-4398-9a31-0d136fd62ac1"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 16, 10, 48, 42, 872, DateTimeKind.Utc).AddTicks(4942));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("2c73a5b5-bf8f-4398-9a31-0d136fd62ac2"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 16, 10, 48, 42, 872, DateTimeKind.Utc).AddTicks(5924));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("3b73a5b5-bf8f-4398-9a31-0d136fd62ac3"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 16, 10, 48, 42, 872, DateTimeKind.Utc).AddTicks(5929));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("4d73a5b5-bf8f-4398-9a31-0d136fd62ac4"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 16, 10, 48, 42, 872, DateTimeKind.Utc).AddTicks(5930));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("5e73a5b5-bf8f-4398-9a31-0d136fd62ac5"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 16, 10, 48, 42, 872, DateTimeKind.Utc).AddTicks(5932));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("6f73a5b5-bf8f-4398-9a31-0d136fd62ac6"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 16, 10, 48, 42, 872, DateTimeKind.Utc).AddTicks(5933));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("7a73a5b5-bf8f-4398-9a31-0d136fd62ac7"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 16, 10, 48, 42, 872, DateTimeKind.Utc).AddTicks(5934));
+
+            migrationBuilder.UpdateData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: new Guid("8b73a5b5-bf8f-4398-9a31-0d136fd62ac8"),
+                column: "CreatedAt",
+                value: new DateTime(2025, 9, 16, 10, 48, 42, 872, DateTimeKind.Utc).AddTicks(5936));
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StaffProfiles_ReportingManagerId",
+                table: "StaffProfiles",
+                column: "ReportingManagerId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_StaffProfiles_Users_ReportingManagerId",
+                table: "StaffProfiles",
+                column: "ReportingManagerId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/server/RecruitmentSystem/RecruitmentSystem.Infrastructure/Repositories/StaffProfileRepository.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Infrastructure/Repositories/StaffProfileRepository.cs
@@ -1,0 +1,89 @@
+using Microsoft.EntityFrameworkCore;
+using RecruitmentSystem.Core.Entities;
+using RecruitmentSystem.Core.Interfaces;
+using RecruitmentSystem.Infrastructure.Data;
+
+namespace RecruitmentSystem.Infrastructure.Repositories
+{
+    public class StaffProfileRepository : IStaffProfileRepository
+    {
+        private readonly ApplicationDbContext _context;
+
+        public StaffProfileRepository(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<StaffProfile> CreateAsync(StaffProfile profile)
+        {
+            profile.CreatedAt = DateTime.UtcNow;
+            profile.UpdatedAt = DateTime.UtcNow;
+
+            _context.StaffProfiles.Add(profile);
+            await _context.SaveChangesAsync();
+            return profile;
+        }
+
+        public async Task<bool> DeleteAsync(Guid id)
+        {
+            var profile = await _context.StaffProfiles.FindAsync(id);
+            if (profile == null) return false;
+
+            _context.StaffProfiles.Remove(profile);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        public async Task<bool> ExistsAsync(Guid id)
+        {
+            return await _context.StaffProfiles.AnyAsync(sp => sp.Id == id);
+        }
+
+        public async Task<bool> ExistsByUserIdAsync(Guid userId)
+        {
+            return await _context.StaffProfiles.AnyAsync(sp => sp.UserId == userId);
+        }
+
+        public async Task<IEnumerable<StaffProfile>> GetActiveStaffAsync()
+        {
+            return await _context.StaffProfiles
+                .Where(sp => sp.Status == "Active")
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<StaffProfile>> GetByDepartmentAsync(string department)
+        {
+            return await _context.StaffProfiles
+                .Where(sp => sp.Department == department)
+                .ToListAsync();
+        }
+
+        public async Task<StaffProfile?> GetByEmployeeCodeAsync(string employeeCode)
+        {
+            return await _context.StaffProfiles.FirstOrDefaultAsync(sp => sp.EmployeeCode == employeeCode);
+        }
+
+        public async Task<StaffProfile?> GetByIdAsync(Guid id)
+        {
+            return await _context.StaffProfiles
+                .Include(sp => sp.User)
+                .FirstOrDefaultAsync(sp => sp.Id == id);
+        }
+
+        public async Task<StaffProfile?> GetByUserIdAsync(Guid userId)
+        {
+            return await _context.StaffProfiles
+                .Include(sp => sp.User)
+                .FirstOrDefaultAsync(sp => sp.UserId == userId);
+        }
+
+        public async Task<StaffProfile> UpdateAsync(StaffProfile profile)
+        {
+            profile.UpdatedAt = DateTime.UtcNow;
+
+            _context.StaffProfiles.Update(profile);
+            await _context.SaveChangesAsync();
+            return profile;
+        }
+    }
+}

--- a/server/RecruitmentSystem/RecruitmentSystem.Services/Implementations/EmailService.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Services/Implementations/EmailService.cs
@@ -75,6 +75,23 @@ namespace RecruitmentSystem.Services.Implementations
             }
         }
 
+        public async Task<bool> SendStaffRegistrationEmailAsync(string toEmail, string userName, string role)
+        {
+            try
+            {
+                var subject = "Welcome to ROIMA Intelligence - Staff Account Created";
+                var htmlContent = GenerateStaffRegistrationTemplate(userName, role);
+                var textContent = GenerateStaffRegistrationText(userName, role);
+
+                return await SendEmailAsync(toEmail, subject, htmlContent, textContent);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send staff registration email to {Email}", toEmail);
+                return false;
+            }
+        }
+
         public async Task<bool> SendBulkWelcomeEmailAsync(string toEmail, string userName, string password, bool isDefaultPassword)
         {
             try
@@ -349,6 +366,80 @@ We're thrilled to have you join the ROIMA Intelligence community!
 
 Best regards,
 The ROIMA Intelligence Recruitment Team";
+        }
+
+        private string GenerateStaffRegistrationTemplate(string userName, string role)
+        {
+            return $@"
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <meta charset='utf-8'>
+                    <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+                    <title>Welcome - Staff Account</title>
+                    <style>
+                        body {{ font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; }}
+                        .header {{ background-color: #007bff; color: white; padding: 20px; text-align: center; border-radius: 5px 5px 0 0; }}
+                        .content {{ background-color: #f9f9f9; padding: 30px; border-radius: 0 0 5px 5px; }}
+                        .button {{ display: inline-block; padding: 12px 25px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px; margin: 20px 0; }}
+                        .footer {{ text-align: center; margin-top: 20px; font-size: 12px; color: #666; }}
+                        .role-badge {{ background-color: #e9ecef; color: #495057; padding: 5px 10px; border-radius: 20px; font-weight: bold; display: inline-block; margin: 10px 0; }}
+                        .features {{ background-color: white; padding: 20px; border-radius: 5px; margin: 20px 0; }}
+                    </style>
+                </head>
+                <body>
+                    <div class='header'>
+                        <h1>Welcome to ROIMA Intelligence!</h1>
+                    </div>
+                    <div class='content'>
+                        <h2>Hello {userName}!</h2>
+                        <p>Your staff account has been successfully created by our HR team. Welcome to ROIMA Intelligence's Recruitment System.</p>
+                        <div style='text-align: center;'>
+                            <span class='role-badge'>Role: {role}</span>
+                        </div>
+                        <div class='features'>
+                            <h3>🚀 Your Responsibilities:</h3>
+                            <ul>
+                                <li><strong>Access the system</strong> using your email and assigned password</li>
+                                <li><strong>Complete your staff profile</strong> with your details</li>
+                                <li><strong>Manage recruitment processes</strong> based on your role permissions</li>
+                                <li><strong>Collaborate with team members</strong> on hiring decisions</li>
+                            </ul>
+                        </div>
+                        <div style='text-align: center;'>
+                            <a href='#' class='button'>🚀 Login to Your Account</a>
+                        </div>
+                        <p>Please check your profile and update any necessary information. If you have any questions about your role or system access, contact the HR department.</p>
+                        <p>Welcome to the team!</p>
+                        <p>Best regards,<br>The ROIMA Intelligence HR Team</p>
+                    </div>
+                    <div class='footer'>
+                        <p>&copy; 2024 Recruitment System. All rights reserved.</p>
+                    </div>
+                </body>
+                </html>";
+        }
+
+        private string GenerateStaffRegistrationText(string userName, string role)
+        {
+            return $@"Hello {userName},
+
+Your staff account has been successfully created by our HR team. Welcome to ROIMA Intelligence's Recruitment System.
+
+Role: {role}
+
+🚀 Your Responsibilities:
+• Access the system using your email and assigned password
+• Complete your staff profile with your details
+• Manage recruitment processes based on your role permissions
+• Collaborate with team members on hiring decisions
+
+Please check your profile and update any necessary information. If you have any questions about your role or system access, contact the HR department.
+
+Welcome to the team!
+
+Best regards,
+The ROIMA Intelligence HR Team";
         }
 
         private static string StripHtml(string html)

--- a/server/RecruitmentSystem/RecruitmentSystem.Services/Implementations/MailKitEmailService.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Services/Implementations/MailKitEmailService.cs
@@ -83,6 +83,23 @@ namespace RecruitmentSystem.Services.Implementations
             }
         }
 
+        public async Task<bool> SendStaffRegistrationEmailAsync(string toEmail, string userName, string role)
+        {
+            try
+            {
+                var subject = "Welcome to ROIMA Intelligence - Staff Account Created";
+                var htmlContent = GenerateStaffRegistrationTemplate(userName, role);
+                var textContent = GenerateStaffRegistrationText(userName, role);
+
+                return await SendEmailAsync(toEmail, subject, htmlContent, textContent);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send staff registration email to {Email}", toEmail);
+                return false;
+            }
+        }
+
         public async Task<bool> SendBulkWelcomeEmailAsync(string toEmail, string userName, string password, bool isDefaultPassword)
         {
             try
@@ -607,6 +624,58 @@ We're thrilled to have you join the ROIMA Intelligence community!
 
 Best regards,
 The ROIMA Intelligence Recruitment Team";
+        }
+
+        private string GenerateStaffRegistrationTemplate(string userName, string role)
+        {
+            string dashboardUrl = _configuration["AppSettings:DashboardUrl"] ?? "#";
+
+            string body = $@"
+                <h2>Welcome to ROIMA Intelligence!</h2>
+                <p>Hello {userName},</p>
+                <p>Your staff account has been successfully created by our HR team. Welcome to ROIMA Intelligence's Recruitment System.</p>
+                <div style='text-align: center; margin: 20px 0;'>
+                    <span style='background: #e9ecef; color: #495057; padding: 8px 16px; border-radius: 20px; font-weight: bold; display: inline-block;'>Role: {role}</span>
+                </div>
+                <div class='features-list'>
+                    <h3 style='margin-top: 0; color: #0c4a6e;'>🚀 Your Responsibilities:</h3>
+                    <ul>
+                        <li><strong>Access the system</strong> using your email and assigned password</li>
+                        <li><strong>Complete your staff profile</strong> with your details</li>
+                        <li><strong>Manage recruitment processes</strong> based on your role permissions</li>
+                        <li><strong>Collaborate with team members</strong> on hiring decisions</li>
+                    </ul>
+                </div>
+                <div style='text-align: center;'>
+                    <a href='{dashboardUrl}' class='button'>🚀 Login to Your Account</a>
+                </div>
+                <p>Please check your profile and update any necessary information. If you have any questions about your role or system access, contact the HR department.</p>
+                <p>Welcome to the team!</p>
+                <p>Best regards,<br>The ROIMA Intelligence HR Team</p>";
+
+            return GenerateBaseEmailTemplate("Welcome to ROIMA Intelligence - Staff Account", "Welcome to ROIMA Intelligence!", body);
+        }
+
+        private string GenerateStaffRegistrationText(string userName, string role)
+        {
+            return $@"Hello {userName},
+
+Your staff account has been successfully created by our HR team. Welcome to ROIMA Intelligence's Recruitment System.
+
+Role: {role}
+
+🚀 Your Responsibilities:
+• Access the system using your email and assigned password
+• Complete your staff profile with your details
+• Manage recruitment processes based on your role permissions
+• Collaborate with team members on hiring decisions
+
+Please check your profile and update any necessary information. If you have any questions about your role or system access, contact the HR department.
+
+Welcome to the team!
+
+Best regards,
+The ROIMA Intelligence HR Team";
         }
 
         private static string StripHtml(string html)

--- a/server/RecruitmentSystem/RecruitmentSystem.Services/Implementations/StaffProfileService.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Services/Implementations/StaffProfileService.cs
@@ -1,0 +1,138 @@
+using AutoMapper;
+using Microsoft.Extensions.Logging;
+using RecruitmentSystem.Core.Entities;
+using RecruitmentSystem.Core.Interfaces;
+using RecruitmentSystem.Services.Interfaces;
+using RecruitmentSystem.Shared.DTOs;
+
+namespace RecruitmentSystem.Services.Implementations
+{
+    public class StaffProfileService : IStaffProfileService
+    {
+
+        private readonly IStaffProfileRepository _repository;
+        private readonly IMapper _mapper;
+        private readonly ILogger<StaffProfileService> _logger;
+
+        public StaffProfileService(
+            IStaffProfileRepository repository,
+            IMapper mapper,
+            ILogger<StaffProfileService> logger)
+        {
+            _repository = repository;
+            _mapper = mapper;
+            _logger = logger;
+        }
+
+        public async Task<StaffProfileResponseDto> CreateProfileAsync(CreateStaffProfileDto dto, Guid userId)
+        {
+            try
+            {
+                if (await _repository.ExistsByUserIdAsync(userId))
+                {
+                    _logger.LogWarning("A staff profile already exists for user {UserId}.", userId);
+                    throw new InvalidOperationException("A staff profile already exists for this user.");
+                }
+
+                var profile = _mapper.Map<StaffProfile>(dto);
+                profile.UserId = userId;
+
+                var createdProfile = await _repository.CreateAsync(profile);
+                var profileWithUser = await _repository.GetByIdAsync(createdProfile.Id);
+                return _mapper.Map<StaffProfileResponseDto>(profileWithUser);
+            }
+            catch (InvalidOperationException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating staff profile for user {UserId}", userId);
+                throw;
+            }
+        }
+
+        public async Task<bool> DeleteProfileAsync(Guid id)
+        {
+            try
+            {
+                var result = await _repository.DeleteAsync(id);
+
+                if (!result)
+                {
+                    throw new KeyNotFoundException("Staff profile not found.");
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deleting staff profile with ID {Id}", id);
+                throw;
+            }
+        }
+
+        public async Task<StaffProfileResponseDto?> GetByIdAsync(Guid id)
+        {
+            try
+            {
+                var profile = await _repository.GetByIdAsync(id);
+                if (profile == null)
+                {
+                    _logger.LogWarning("Staff profile not found for ID {Id}.", id);
+                    return null;
+                }
+
+                return _mapper.Map<StaffProfileResponseDto>(profile);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving staff profile with ID {Id}.", id);
+                throw;
+            }
+        }
+
+        public async Task<StaffProfileResponseDto?> GetByUserIdAsync(Guid userId)
+        {
+            try
+            {
+                var profile = await _repository.GetByUserIdAsync(userId);
+                if (profile == null)
+                {
+                    _logger.LogWarning("Staff profile not found for user ID {UserId}.", userId);
+                    return null;
+                }
+
+                return _mapper.Map<StaffProfileResponseDto>(profile);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving staff profile for user ID {UserId}.", userId);
+                throw;
+            }
+        }
+
+        public async Task<StaffProfileResponseDto?> UpdateProfileAsync(Guid id, UpdateStaffProfileDto dto)
+        {
+            try
+            {
+                var profile = await _repository.GetByIdAsync(id);
+                if (profile == null)
+                {
+                    _logger.LogWarning("Staff profile not found for ID {Id}.", id);
+                    return null;
+                }
+
+                _mapper.Map(dto, profile);
+                var updatedProfile = await _repository.UpdateAsync(profile);
+                var profileWithUser = await _repository.GetByIdAsync(updatedProfile.Id);
+                return _mapper.Map<StaffProfileResponseDto>(profileWithUser);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating staff profile with ID {Id}.", id);
+                throw;
+            }
+        }
+    }
+}

--- a/server/RecruitmentSystem/RecruitmentSystem.Services/Interfaces/IEmailService.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Services/Interfaces/IEmailService.cs
@@ -11,6 +11,7 @@ namespace RecruitmentSystem.Services.Interfaces
         Task<bool> SendEmailVerificationAsync(string toEmail, string userName, string verificationToken, string verificationUrl);
         Task<bool> SendPasswordResetAsync(string toEmail, string userName, string resetToken, string resetUrl);
         Task<bool> SendWelcomeEmailAsync(string toEmail, string userName);
+        Task<bool> SendStaffRegistrationEmailAsync(string toEmail, string userName, string role);
         Task<bool> SendBulkWelcomeEmailAsync(string toEmail, string userName, string password, bool isDefaultPassword);
         Task<bool> SendEmailAsync(string toEmail, string subject, string htmlContent, string? textContent = null);
     }

--- a/server/RecruitmentSystem/RecruitmentSystem.Services/Interfaces/IStaffProfileService.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Services/Interfaces/IStaffProfileService.cs
@@ -1,0 +1,13 @@
+using RecruitmentSystem.Shared.DTOs;
+
+namespace RecruitmentSystem.Services.Interfaces
+{
+    public interface IStaffProfileService
+    {
+        Task<StaffProfileResponseDto> CreateProfileAsync(CreateStaffProfileDto dto, Guid userId);
+        Task<StaffProfileResponseDto?> GetByIdAsync(Guid id);
+        Task<StaffProfileResponseDto?> GetByUserIdAsync(Guid userId);
+        Task<StaffProfileResponseDto?> UpdateProfileAsync(Guid id, UpdateStaffProfileDto dto);
+        Task<bool> DeleteProfileAsync(Guid id);
+    }
+}

--- a/server/RecruitmentSystem/RecruitmentSystem.Services/Mappings/StaffProfile.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Services/Mappings/StaffProfile.cs
@@ -1,0 +1,34 @@
+using AutoMapper;
+using RecruitmentSystem.Shared.DTOs;
+using RecruitmentSystem.Core.Entities;
+
+namespace RecruitmentSystem.Services.Mappings
+{
+    public class StaffProfileMappingProfile : Profile
+    {
+        public StaffProfileMappingProfile()
+        {
+            CreateMap<StaffProfile, StaffProfileResponseDto>()
+                .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.User.FirstName))
+                .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.User.LastName))
+                .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.User.Email))
+                .ForMember(dest => dest.PhoneNumber, opt => opt.MapFrom(src => src.User.PhoneNumber));
+
+            CreateMap<CreateStaffProfileDto, StaffProfile>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.UserId, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.User, opt => opt.Ignore());
+
+            CreateMap<UpdateStaffProfileDto, StaffProfile>()
+                .ForMember(dest => dest.Id, opt => opt.Ignore())
+                .ForMember(dest => dest.UserId, opt => opt.Ignore())
+                .ForMember(dest => dest.CreatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.UpdatedAt, opt => opt.Ignore())
+                .ForMember(dest => dest.User, opt => opt.Ignore())
+                .ForMember(dest => dest.EmployeeCode, opt => opt.Ignore())
+                .ForAllMembers(opts => opts.Condition((src, dest, srcMember) => srcMember != null));
+        }
+    }
+}

--- a/server/RecruitmentSystem/RecruitmentSystem.Services/RecruitmentSystem.Services.csproj
+++ b/server/RecruitmentSystem/RecruitmentSystem.Services/RecruitmentSystem.Services.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
     <PackageReference Include="AWSSDK.S3" Version="4.0.7.1" />
-    <PackageReference Include="EPPlus" Version="8.1.1" />
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="MailKit" Version="4.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />

--- a/server/RecruitmentSystem/RecruitmentSystem.Shared/DTOs/StaffProfileDTOs.cs
+++ b/server/RecruitmentSystem/RecruitmentSystem.Shared/DTOs/StaffProfileDTOs.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace RecruitmentSystem.Shared.DTOs
+{
+    public class CreateStaffProfileDto
+    {
+        [Required]
+        [StringLength(50)]
+        public string? EmployeeCode { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string? Department { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string? Location { get; set; }
+
+        [Required]
+        [StringLength(50)]
+        public string? Status { get; set; }
+
+        public DateTime? JoinedDate { get; set; }
+    }
+
+    public class StaffProfileResponseDto
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public string? EmployeeCode { get; set; }
+        public string? Department { get; set; }
+        public string? Location { get; set; }
+        public string? Status { get; set; }
+        public DateTime? JoinedDate { get; set; }
+
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+        public string? Email { get; set; }
+        public string? PhoneNumber { get; set; }
+    }
+
+    public class UpdateStaffProfileDto
+    {
+        [StringLength(100)]
+        public string? Department { get; set; }
+
+        [StringLength(100)]
+        public string? Location { get; set; }
+
+        [StringLength(50)]
+        public string? Status { get; set; }
+
+        public DateTime? JoinedDate { get; set; }
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive staff profile management feature to the recruitment system, including a new entity, repository interface, and a dedicated API controller for staff profiles. It also updates the registration email logic for staff and makes several schema adjustments in the application database snapshot.

**Staff Profile Feature Implementation**

* Added the `StaffProfile` entity to represent staff details, including user association, employee code, department, location, status, and joined date. (`server/RecruitmentSystem/RecruitmentSystem.Core/Entities/StaffProfile.cs`)
* Created the `IStaffProfileRepository` interface to define methods for staff profile CRUD operations and queries by various attributes. (`server/RecruitmentSystem/RecruitmentSystem.Core/Interfaces/IStaffProfileRepository.cs`)
* Implemented the `StaffProfileController` with endpoints for creating, retrieving (by ID, by user ID, current user), updating, and deleting staff profiles, including role-based access control and error handling. (`server/RecruitmentSystem/RecruitmentSystem.API/Controllers/StaffProfileController.cs`)

**Registration and Email Logic**

* Updated staff registration logic to send a role-specific registration email using `SendStaffRegistrationEmailAsync` instead of a generic welcome email, and included the assigned roles in the email. (`server/RecruitmentSystem/RecruitmentSystem.API/Controllers/AuthenticationController.cs`)

**Database Schema Adjustments**

* Modified the database snapshot to make several candidate-related fields optional (removed `.IsRequired()`), such as `College`, `CurrentLocation`, `Degree`, `GitHubProfile`, `LinkedInProfile`, `PortfolioUrl`, `ResumeFileName`, `ResumeFilePath`, `Source`, `EmploymentType`, `JobDescription`, `Location`, and `Description`. Also changed `GPA` to be non-nullable. (`server/RecruitmentSystem/RecruitmentSystem.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs`) [[1]](diffhunk://#diff-c602dc592e221d9d25b35d61e6af8fe993067fab15ecbd489a5fa78237959751L141-R141) [[2]](diffhunk://#diff-c602dc592e221d9d25b35d61e6af8fe993067fab15ecbd489a5fa78237959751L173) [[3]](diffhunk://#diff-c602dc592e221d9d25b35d61e6af8fe993067fab15ecbd489a5fa78237959751L187-L200) [[4]](diffhunk://#diff-c602dc592e221d9d25b35d61e6af8fe993067fab15ecbd489a5fa78237959751L211-L234) [[5]](diffhunk://#diff-c602dc592e221d9d25b35d61e6af8fe993067fab15ecbd489a5fa78237959751L309) [[6]](diffhunk://#diff-c602dc592e221d9d25b35d61e6af8fe993067fab15ecbd489a5fa78237959751L320) [[7]](diffhunk://#diff-c602dc592e221d9d25b35d61e6af8fe993067fab15ecbd489a5fa78237959751L330) [[8]](diffhunk://#diff-c602dc592e221d9d25b35d61e6af8fe993067fab15ecbd489a5fa78237959751L361)